### PR TITLE
fix bug (php_version < '5.6.13')

### DIFF
--- a/modules/exploits/multi/http/joomla_http_header_rce.rb
+++ b/modules/exploits/multi/http/joomla_http_header_rce.rb
@@ -67,9 +67,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vulnerable = false
     vulnerable = true if php_version < '5.4'
-    vulnerable = true if php_version.start_with?('5.4') && php_version < '5.4.45'
-    vulnerable = true if php_version.start_with?('5.5') && php_version < '5.5.29'
-    vulnerable = true if php_version.start_with?('5.6') && php_version < '5.6.13'
+    vulnerable = true if php_version.start_with?('5.4') && php_version.gsub('5.4.', '').to_i < 45  # < 5.4.45
+    vulnerable = true if php_version.start_with?('5.5') && php_version.gsub('5.5.', '').to_i < 29  # < 5.5.29
+    vulnerable = true if php_version.start_with?('5.6') && php_version.gsub('5.6.', '').to_i < 13  # < 5.6.13
 
     unless vulnerable
       vprint_error('This module currently does not work against this PHP version')


### PR DESCRIPTION
[#6355](https://github.com/rapid7/metasploit-framework/pull/6355).   If my **```php_version```** is "5.6.3", **```vulnerable```** will be false.